### PR TITLE
fixing consistency error with generated scripts directory

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -61,7 +61,7 @@ gulp.task('build:css', function() {
 });
 
 gulp.task('build:js', function() {
-	return gulp.src('src/js/*.js')
+	return gulp.src('src/scripts/*.js')
 	           .pipe(gulp.dest('dist/js'));
 
 });


### PR DESCRIPTION
By default, the application creates a `scripts/` directory in `src/`, but the task to build js into `dist/` reads from the directory `src/js/`. Presumably the two should match up by default so as not to cause unexpected behaviour.